### PR TITLE
Add streamlit GUI for agent

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -64,6 +64,7 @@ _exclude:
   - "{{ '*/app/api' if project_type not in ['api-microservice', 'agent'] else '' }}"
 
   - "{{ '*/app/agent.py' if project_type != 'agent' else '' }}"
+  - "{{ '*/app/gui.py' if project_type != 'agent' else '' }}"
 
   - "{{ '*/app/api.py' if project_type != 'api-monolith' else '' }}"
   - "{{ '*/app/user' if project_type != 'api-monolith' else '' }}"

--- a/{{project_name}}/.gitignore
+++ b/{{project_name}}/.gitignore
@@ -152,3 +152,6 @@ volumes
 
 # SSL certificates
 *.pem
+
+# Streamlit secrets
+.streamlit/

--- a/{{project_name}}/app/agent.py
+++ b/{{project_name}}/app/agent.py
@@ -2,7 +2,6 @@ import asyncio
 
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
-# from pydantic_ai.providers.ollama import OllamaProvider
 from pydantic_ai import Agent
 from pydantic_ai.tools import Tool
 from pydantic_ai.mcp import MCPServerStreamableHTTP
@@ -34,7 +33,6 @@ class AgentManager:
     
     def _create_agent(self, model: str, system_prompt: str) -> Agent:
         model = OpenAIChatModel(model, provider=OpenAIProvider(api_key=settings.api_key))
-        # model = OpenAIChatModel(model_name='llama3', provider=OllamaProvider(base_url='http://localhost:11434'))
         return Agent(
             model=model,
             deps_type=dict[str, str],

--- a/{{project_name}}/app/gui.py
+++ b/{{project_name}}/app/gui.py
@@ -55,7 +55,7 @@ st.divider()
 # ---------- sidebar ----------
 
 with st.sidebar:
-    if st.button("New chat"):
+    if st.button("New chat", icon="💡"):
         st.session_state.chats += 1
         st.session_state.active_chat = st.session_state.chats
     st.divider()

--- a/{{project_name}}/app/gui.py
+++ b/{{project_name}}/app/gui.py
@@ -40,11 +40,11 @@ if "active_chat" not in st.session_state:
     st.session_state.active_chat = 1
 
 
-def geticon(i: int) -> str:
-    return '📌' if i == st.session_state.active_chat else '💤'
+def geticon(chat_number: int) -> str:
+    return '📌' if chat_number == st.session_state.active_chat else '💤'
 
 
-# ----------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------------------------
 
 st.title(":robot: Your AI Assistant :robot:")
 
@@ -59,10 +59,10 @@ with st.sidebar:
         st.session_state.chats += 1
         st.session_state.active_chat = st.session_state.chats
     st.divider()
-    for i in range(1, st.session_state["chats"] + 1):
-        if st.button(f"Chat {i}",
-                     key=f"chat{i}", icon=geticon(i)):
-            st.session_state.active_chat = i
+    for chat_nr in range(1, st.session_state["chats"] + 1):
+        if st.button(f"Chat {chat_nr}",
+                     key=f"chat{chat_nr}", icon=geticon(chat_nr)):
+            st.session_state.active_chat = chat_nr
             st.rerun()
 
 # -----------------------------
@@ -106,6 +106,6 @@ if prompt := st.chat_input("Ask me something"):
         st.session_state[f"messages{st.session_state["active_chat"]}"].append({"role": "assistant", "text": full_response})
 
 
-# ----------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------------------------
 
 

--- a/{{project_name}}/app/gui.py
+++ b/{{project_name}}/app/gui.py
@@ -7,17 +7,20 @@ from streamlit.errors import StreamlitSecretNotFoundError
 from openai import AuthenticationError
 from pydantic_core._pydantic_core import ValidationError
 
-from app.config import settings
-os.environ["API_KEY"] = settings.api_key
-
-# Try to authenticate with streamlit secrets
-# if .env doesn't provide an api key
-if settings.api_key == "":
+try:
+    from app.config import settings
+    os.environ["API_KEY"] = settings.api_key
+except (ValidationError, AttributeError):
+    # Try to authenticate with streamlit secrets
+    # if .env doesn't provide an api key
     try:
         os.environ["API_KEY"] = st.secrets["API_KEY"]
     except StreamlitSecretNotFoundError:
         st.warning("Provide a valid API key.")
         raise
+
+if "MCP_URL" in st.secrets:
+    os.environ["MCP_URL"] = st.secrets["MCP_URL"]
 
 from app.agent import AgentManager
 
@@ -28,12 +31,17 @@ try:
     asyncio.run(agent_manager.initialize())
 except ExceptionGroup:
     st.markdown("Failed to initialize the agent...")
+    raise
 
 
 if "chats" not in st.session_state:
     st.session_state.chats = 1
 if "active_chat" not in st.session_state:
     st.session_state.active_chat = 1
+
+
+def geticon(i: int) -> str:
+    return '📌' if i == st.session_state.active_chat else '💤'
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -51,10 +59,11 @@ with st.sidebar:
         st.session_state.chats += 1
         st.session_state.active_chat = st.session_state.chats
     st.divider()
-    st.session_state.chat_buttons = []
     for i in range(1, st.session_state["chats"] + 1):
-        if st.button(f"Chat {i}", key=f"chat{i}"):
+        if st.button(f"Chat {i}",
+                     key=f"chat{i}", icon=geticon(i)):
             st.session_state.active_chat = i
+            st.rerun()
 
 # -----------------------------
 
@@ -82,9 +91,11 @@ if prompt := st.chat_input("Ask me something"):
         except AuthenticationError:
             st.warning("Please provide an api key in .env")
             response = ""
+            raise
         except (ExceptionGroup, RuntimeError):
-            st.warning("Failed to connect with MCP server.")
+            st.warning("Failed to connect with agent or MCP server.")
             response = ""
+            raise
 
         # Split response into chunks to imitate AI behaviour
         for chunk in response.split():

--- a/{{project_name}}/app/gui.py
+++ b/{{project_name}}/app/gui.py
@@ -46,7 +46,7 @@ def geticon(i: int) -> str:
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-st.title("Your AI Assistant")
+st.title(":robot: Your AI Assistant :robot:")
 
 
 st.divider()

--- a/{{project_name}}/app/gui.py
+++ b/{{project_name}}/app/gui.py
@@ -5,10 +5,9 @@ import os
 import streamlit as st
 from openai import AuthenticationError
 
+os.environ["API_KEY"] = st.secrets["API_KEY"]
 from app.agent import AgentManager
 
-
-os.environ["API_KEY"] = st.secrets["API_KEY"]
 
 agent_manager = AgentManager()
 

--- a/{{project_name}}/app/gui.py
+++ b/{{project_name}}/app/gui.py
@@ -1,0 +1,92 @@
+import asyncio
+import time
+import os
+
+import streamlit as st
+from openai import AuthenticationError
+
+from app.agent import AgentManager
+
+
+os.environ["API_KEY"] = st.secrets["API_KEY"]
+
+agent_manager = AgentManager()
+
+if os.environ.get("API_KEY") == "":
+    st.markdown("Please provide an API key in .streamlit/secrets.toml to continue...")
+else:
+    try:
+        asyncio.run(agent_manager.initialize())
+    except ExceptionGroup:
+        st.markdown("Couldn't initialize the agent...")
+
+
+if "chats" not in st.session_state:
+    st.session_state.chats = 1
+if "active_chat" not in st.session_state:
+    st.session_state.active_chat = 1
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+st.title("Your AI Assistant")
+
+
+st.divider()
+
+
+# ---------- sidebar ----------
+
+with st.sidebar:
+    if st.button("New chat"):
+        st.session_state.chats += 1
+        st.session_state.active_chat = st.session_state.chats
+    st.divider()
+    st.session_state.chat_buttons = []
+    for i in range(st.session_state["chats"]):
+        i += 1
+        if st.button(f"Chat {i}", key=f"chat{i}"):
+            st.session_state.active_chat = i
+
+# -----------------------------
+
+
+if f"messages{st.session_state["active_chat"]}" not in st.session_state:
+    st.session_state[f"messages{st.session_state["chats"]}"] = []
+
+for message in st.session_state[f"messages{st.session_state["active_chat"]}"]:
+    with st.chat_message(message["role"]):
+        st.markdown(message["text"])
+
+if prompt := st.chat_input("Ask me something"):
+    st.session_state[f"messages{st.session_state["active_chat"]}"].append({"role": "human", "text": prompt})
+
+    with st.chat_message("human"):
+        st.markdown(prompt)
+
+    with st.chat_message("assistant"):
+        placeholder = st.empty()
+        full_response = ""
+
+        try:
+            with st.spinner("running...", show_time=True):
+                response = asyncio.run(agent_manager.handle_message(prompt))
+        except AuthenticationError:
+            st.warning("Please provide an api key in .env")
+            response = ""
+        except RuntimeError:
+            st.warning("Agent not initialized.")
+            response = ""
+
+        # Split response into chunks to imitate AI behaviour
+        for chunk in response.split():
+            full_response += chunk + " "
+            time.sleep(0.04)
+            placeholder.markdown(full_response + "▌")
+        placeholder.markdown(full_response)
+        st.session_state[f"messages{st.session_state["active_chat"]}"].append({"role": "assistant", "text": full_response})
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+

--- a/{{project_name}}/pyproject.toml.jinja
+++ b/{{project_name}}/pyproject.toml.jinja
@@ -16,7 +16,7 @@ dependencies = [
     "fastmcp>=2.12.2",
     "pydantic>=2.11.7",
     {% elif project_type == "agent" %}
-    "pydantic-ai-slim[mcp]>=1.0.8",
+    "pydantic-ai-slim[mcp, openai]>=1.0.8",
     {% endif %}
     {% if project_type in ["api-monolith", "api-microservice", "agent"] %}
     "fastapi>=0.116.1",


### PR DESCRIPTION
This pull request adds an interface to talk with the agent via streamlit (#14). The gui is launched with `uv run streamlit run app/gui.py`.
It imitates chats with LLMs, e.g. as seen in ChatGPT.

If an api key is not found in `.env`, it will be accessed from streamlit's secrets (via `.streamlit/secrets.toml` or on the streamlit website)

<img width="1914" height="874" alt="image" src="https://github.com/user-attachments/assets/a17a79fa-fd32-4536-8725-6054c40c2fac" />
